### PR TITLE
add suporte Yup.array().of()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,14 +83,18 @@ function updateIn(obj: any, path: string, value: any): any {
       destinationObject[pathArray[i]] = {}
     }
     if (RegExp(/\[([^)]+)\]/).exec(pathArray[i])) {
-
       const [relativePath, index] = pathArray[i].split('[')
-      const p = Number(index.split("]")[0])
+      const p = Number(index.split(']')[0])
+
+      if (!Array.isArray(destinationObject[relativePath])) {
+        destinationObject[relativePath] = []
+      }
 
       if (!isNaN(p)) {
-        destinationObject[relativePath] = [destinationObject[pathArray[(p)]]]
+        destinationObject[relativePath][p] = destinationObject[pathArray[i]]
       }
     }
+
     destinationObject = destinationObject[pathArray[i]]
   }
   destinationObject[pathArray[pathArray.length - 1]] = value

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-import { Schema } from 'yup'
+import { Schema, ValidationError } from 'yup'
 
 type Values = {
   [field: string]: any
@@ -62,7 +62,7 @@ function useYup<T extends Values>(
  * Transform Yup errors to a ValidationErrors object
  */
 function yupToValidationErrors<T extends Values>(
-  yupError: any
+  yupError: ValidationError
 ): ValidationErrors<T> {
   let errors: any = {} as ValidationErrors<Values>
   if (yupError.inner.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,15 @@ function updateIn(obj: any, path: string, value: any): any {
     if (pathArray[i] in destinationObject === false) {
       destinationObject[pathArray[i]] = {}
     }
+    if (RegExp(/\[([^)]+)\]/).exec(pathArray[i])) {
+
+      const [relativePath, index] = pathArray[i].split('[')
+      const p = Number(index.split("]")[0])
+
+      if (!isNaN(p)) {
+        destinationObject[relativePath] = [destinationObject[pathArray[(p)]]]
+      }
+    }
     destinationObject = destinationObject[pathArray[i]]
   }
   destinationObject[pathArray[pathArray.length - 1]] = value


### PR DESCRIPTION
iamServer: Yup.array().of(yup schema) or iamServer: Yup.array( yup schema), received object with key like this "mykey[0]":{...object}, the solution proposed is "mykey" :[{...object}].
That way I can keep the shape of the error object and form and the error display is easier.